### PR TITLE
attempt to only eslint frontend and not any other files

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Install modules
         run: npm --prefix ./frontend install
       - name: Lint frontend with ESLint
-        run: npx eslint -c ./frontend/.eslintrc.js . --ext .js,.jsx,.ts,.tsx
+        run: npx eslint -c ./frontend/.eslintrc.js ./frontend --ext .js,.jsx,.ts,.tsx


### PR DESCRIPTION
This PR implements a fix so that only the frontend directory is linted and not any other JS files.