### PR TITLE
Implemented new design for login, signup and all password change/request pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,12 +19,12 @@ import ResetPasswordPage from "./pages/ResetPasswordPage";
 import ChangePasswordPage from "./pages/ChangePasswordPage";
 import Wallet from "./pages/Wallet";
 import appwriteApi from "./api/appwriteApi";
-import Typography from "@mui/material/Typography";
 import AdminPage from "./pages/AdminPage";
 import UserArea from "./areas/UserArea";
 import AdminArea from "./areas/AdminArea";
 import Footer from "./components/Footer";
 import Grid from "@mui/material/Grid";
+import HeaderTypography from "./components/HeaderTypography";
 
 /**
  * Main component of the frontend, mostly defining routes and the content to be display in specific routes.
@@ -56,13 +56,13 @@ function App() {
 								<>
 									<Route exact path="/">
 										<CenterFlexBox>
-											<Typography component="h1" variant="h5">
+											<HeaderTypography component="h1" variant="h5">
 												Coming soon!
-											</Typography>
+											</HeaderTypography>
 											<img src={logo} className="App-logo" alt="logo" />
-											<Typography component="h1" variant="h5">
+											<HeaderTypography component="h1" variant="h5">
 												NFT the world!
-											</Typography>
+											</HeaderTypography>
 											<Button
 												sx={{ mt: 2 }}
 												style={{ width: "min(50vw,500px)", minHeight: "min(30vh,150px)", fontSize: "4vh", backgroundColor: "#005438", borderRadius: "15px" }}
@@ -109,19 +109,24 @@ function App() {
 									<Route exact path="/resetPassword">
 										<ResetPasswordPage setUser={setUser} user={user} />
 									</Route>
-									<UserArea user={user}>
-										<Route exact path="/changePassword">
-											<ChangePasswordPage setUser={setUser} user={user} />
-										</Route>
-										<Route exact path="/profile">
-											<Profile setUser={setUser} user={user} />
-										</Route>
-										<AdminArea user={user}>
-											<Route exact path="/admin">
-												<AdminPage setUser={setUser} user={user} />
+									<Route path="/user">
+										<UserArea user={user}>
+											<Route exact path="/user/changePassword">
+												<ChangePasswordPage setUser={setUser} user={user} />
 											</Route>
-										</AdminArea>
-									</UserArea>
+											<Route exact path="/user/profile">
+												<Profile setUser={setUser} user={user} />
+											</Route>
+											<Route exact path="/user/wallets">
+												<Wallet setUser={setUser} user={user} />
+											</Route>
+											<Route exact path="/user/admin">
+												<AdminArea user={user}>
+													<AdminPage setUser={setUser} user={user} />
+												</AdminArea>
+											</Route>
+										</UserArea>
+									</Route>
 									<Route exact path="/confirmEmail">
 										<EmailConfirmPage setUser={setUser} user={user} />
 									</Route>

--- a/frontend/src/areas/AdminArea.js
+++ b/frontend/src/areas/AdminArea.js
@@ -3,6 +3,8 @@
 
 import React, { useEffect, useState } from "react";
 import appwriteApi from "../api/appwriteApi";
+import CenterFlexBox from "../components/CenterFlexBox";
+import ParagraphTypography from "../components/ParagraphTypography";
 
 /**
  * Wrapper component that only displays its children if the user is in the Admins team, otherwise wrapped components
@@ -21,11 +23,19 @@ export default function AdminArea({ children }) {
 	}, []);
 
 	if (!isLoaded){
-		return <></>;
+		return <CenterFlexBox>
+			<ParagraphTypography>
+				Loading
+			</ParagraphTypography>
+		</CenterFlexBox>;
 	}
 
 	if (!userIsAdmin){
-		return <></>;
+		return <CenterFlexBox>
+			<ParagraphTypography>
+				You are trying to access an admin restricted area. If you believe you should access to this area, please contact an admin directly.
+			</ParagraphTypography>
+		</CenterFlexBox>;
 	}
 
 	return <>

--- a/frontend/src/areas/AdminArea.js
+++ b/frontend/src/areas/AdminArea.js
@@ -33,7 +33,7 @@ export default function AdminArea({ children }) {
 	if (!userIsAdmin){
 		return <CenterFlexBox>
 			<ParagraphTypography>
-				You are trying to access an admin restricted area. If you believe you should access to this area, please contact an admin directly.
+				You are trying to access an admin restricted area. If you believe you should have access to this area, please contact an admin directly.
 			</ParagraphTypography>
 		</CenterFlexBox>;
 	}

--- a/frontend/src/areas/UserArea.js
+++ b/frontend/src/areas/UserArea.js
@@ -1,26 +1,26 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2021 Dominic Heil <d.heil@campus.tu-berlin.de>
 
-import React, { useEffect } from "react";
-import useChangeRoute from "../hooks/useChangeRoute";
+import React from "react";
+import ParagraphTypography from "../components/ParagraphTypography";
+import { Link } from "react-router-dom";
+import CenterFlexBox from "../components/CenterFlexBox";
 
 /**
  * Wrapper component that only displays its children if the user is a logged in user, otherwise wrapped components
  * will not be shown.
+ * @param user user object of the currently logged in user or null if not logged in
  * @param children wrapped components that should only be shown logged in users
  * @returns {JSX.Element}
  */
 export default function UserArea({ user, children }) {
-	const changeRoute = useChangeRoute();
-
-	useEffect(() => {
-		if (!user){
-			changeRoute("/");
-		}
-	}, [user]);
 
 	if (!user){
-		return <></>;
+		return <CenterFlexBox>
+			<ParagraphTypography>
+				You are trying to access a user restricted area. Please <Link to="/login" style={{ textDecorationLine: "none", color:"#008425" }}>login</Link>.
+			</ParagraphTypography>
+		</CenterFlexBox>;
 	}
 
 	return <>

--- a/frontend/src/assets/jss/InputFieldJSS.js
+++ b/frontend/src/assets/jss/InputFieldJSS.js
@@ -5,6 +5,7 @@ const WHITE_35 = "#FFFFFF59";
 const WHITE_60 = "#FFFFFF99";
 const WHITE_85 = "#FFFFFFD8";
 
+// JSS for one line input fields
 export const inputFieldStyle = {
 	"& fieldset": {
 		borderColor: WHITE_35,

--- a/frontend/src/assets/jss/InputFieldJSS.js
+++ b/frontend/src/assets/jss/InputFieldJSS.js
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2021 Dominic Heil <d.heil@campus.tu-berlin.de>
+
+const WHITE_35 = "#FFFFFF59";
+const WHITE_60 = "#FFFFFF99";
+const WHITE_85 = "#FFFFFFD8";
+
+export const inputFieldStyle = {
+	"& fieldset": {
+		borderColor: WHITE_35,
+	},
+	"&:hover fieldset": {
+		borderColor: WHITE_60,
+	},
+	"& label": {
+		fontFamily: "Noto Sans",
+		fontSize: "14px",
+		marginTop: "2px"
+	},
+	"& label.Mui-focused": {
+		color: WHITE_60,
+	},
+	"& .MuiFormLabel-asterisk": {
+		color: WHITE_60,
+	},
+	"& .MuiFormLabel-root": {
+		color: WHITE_60,
+	},
+	".MuiOutlinedInput-notchedOutline": {
+		borderWidth: "1px",
+		borderRadius: "7px"
+	},
+	".MuiOutlinedInput-input":{
+		color: "white",
+		fontFamily: "Noto Sans",
+	},
+	"& .MuiOutlinedInput-root": {
+		"&.Mui-focused fieldset": {
+			borderColor: WHITE_60,
+		},
+		"&:hover fieldset": {
+			borderColor: WHITE_85,
+		},
+		"& label.Mui-focused": {
+			color: WHITE_85,
+		},
+	},
+};

--- a/frontend/src/components/CenterFlexBox.js
+++ b/frontend/src/components/CenterFlexBox.js
@@ -16,7 +16,7 @@ export default function CenterFlexBox({ children }) {
 		<CssBaseline />
 		<Box
 			sx={{
-				marginTop: 8,
+				marginTop: 14,
 				display: "flex",
 				flexDirection: "column",
 				alignItems: "center",

--- a/frontend/src/components/EditAdminTeam.js
+++ b/frontend/src/components/EditAdminTeam.js
@@ -7,7 +7,6 @@ import {
 	Button, Divider,
 	FormControlLabel,
 	FormGroup,
-	Typography,
 } from "@mui/material";
 import React, { useState } from "react";
 import Grid from "@mui/material/Grid";
@@ -15,6 +14,7 @@ import TextField from "@mui/material/TextField";
 import Checkbox from "@mui/material/Checkbox";
 import appwriteApi from "../api/appwriteApi";
 import { isValidEmail } from "../utils/utils";
+import ParagraphTypography from "./ParagraphTypography";
 
 /**
  * Component that can be used by admins to invite or remove other admins.
@@ -80,9 +80,9 @@ export default function EditAdminTeam({ user }) {
 		direction="column">
 		<Grid item style={{ width: "100%" }}>
 			<Grid container justify="space-between" style={{ width: "100%" }}>
-				<Typography variant="body1" align="left" gutterBottom>
+				<ParagraphTypography variant="body1" align="left" gutterBottom>
 					Search for a user by their email and remove them from the admins team or send an invite to someone to join the admin teams.
-				</Typography>
+				</ParagraphTypography>
 			</Grid>
 			<Box component="form" onSubmit={checkIfUserIsInAdminTeam} noValidate sx={{ mt: 1 }} >
 				<TextField
@@ -111,20 +111,20 @@ export default function EditAdminTeam({ user }) {
 					<Divider sx={{ mb: 2 }} />
 					<Grid container justify="space-between" style={{ width: "100%" }}>
 						<>
-							<Typography variant="body1" align="left" gutterBottom sx={{ mb: 2 }} >
+							<ParagraphTypography variant="body1" align="left" gutterBottom sx={{ mb: 2 }} >
 								{searchedUserIsInAdminTeam ?
 									<>The user with the email &quot;<b>{searchedUserEmail}</b>&quot; is <b>in</b> the admin team. Below, you can remove them from the admin team.</>
 									:
 									<>The user with the email &quot;<b>{searchedUserEmail}</b>&quot; is <b>not</b> in the admin team. You can invite them to the admin team below.</>
 								}
-							</Typography>
+							</ParagraphTypography>
 							<FormGroup>
 								<FormControlLabel
 									label={searchedUserIsInAdminTeam
 										?
-										<>Are you sure you want to <b>remove</b> this user from the admins team?</>
+										<ParagraphTypography>Are you sure you want to <b>remove</b> this user from the admins team?</ParagraphTypography>
 										:
-										<>Are you sure you want to <b>invite</b> this user to the admins team?</>
+										<ParagraphTypography>Are you sure you want to <b>invite</b> this user to the admins team?</ParagraphTypography>
 									}
 									control={<Checkbox checked={areYouSureChecked} onChange={() => setAreYouSureChecked(prevState => !prevState)}/>}
 								/>

--- a/frontend/src/components/EditAdminTeam.js
+++ b/frontend/src/components/EditAdminTeam.js
@@ -90,7 +90,7 @@ export default function EditAdminTeam({ user }) {
 					required
 					fullWidth
 					id="email"
-					label="Email Address"
+					label="Email"
 					name="email"
 					autoFocus
 				/>

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -6,7 +6,12 @@ import React from "react";
 import { Typography } from "@mui/material";
 import { Link } from "react-router-dom";
 
-
+/**
+ * Wrapper component used to build the footer of the page that is display at the bottom of every page.
+ * @param children  children components that should be shown above the footer, i.e. the rest of the website
+ * @returns {JSX.Element}
+ * @constructor
+ */
 export default function Footer({ children }){
 
 	return <>

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -10,7 +10,7 @@ import { Link } from "react-router-dom";
 export default function Footer({ children }){
 
 	return <>
-		<div style={{ minHeight: "100vh", paddingBottom: "93px" }}>
+		<div style={{ minHeight: "100vh", paddingBottom: "83px" }}>
 			{children}
 		</div>
 		<footer className="footer" style={{ paddingTop: "10px", marginTop: "-83px", height: "83px", display: "inherit" }}>

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -28,43 +28,45 @@ export default function Header({ children, user }) {
 
 	return (
 		<>
-			<Box style={{ width: "100%" }} sx={{ flexGrow: 1 }}>
-				<AppBar position="static" style={{ backgroundColor: "rgba(0,0,0,0)", boxShadow: "0 0 0 0" }}>
-					<Toolbar style={{ overflowX: "none", display: "flex", justifyContent: "space-between" }}>
-						<div style={{ display: "inherit" }}>
-							<Link to="/" style={{ textDecoration: "none", display: "inherit", userSelect: "none" }}>
-								<img src={NftLogo} alt="Logo" style={{ width: "63px", height: "63px", marginRight: "7px" }} />
-								<Typography style={{ fontSize: "17px", fontFamily: "Josefin Sans", lineHeight: "96%", marginTop: "19px", opacity: "86%", color: "white", whiteSpace: "nowrap" }}>
-									NFT<br/>the world!
-								</Typography>
-							</Link>
-							<div style={{ marginTop: "29px", marginLeft: "14px", display: "inherit" }}>
-								<div style={{ width: "15px", height: "0", transform: "rotate(270deg)", border: "1px solid #8d8d8d", color: "#8d8d8d", backgroundColor: "#8d8d8d", float: "left", marginRight: "14px", marginTop: "11px" }}/>
-								<Link to="/faq"  style={{ textDecoration: "none", color: "white" }}>
-									<Typography style={{ fontFamily: "Noto Sans", fontSize: "16px", fontStyle: "normal", fontWeight: "700", lineWeight: "22px", letterSpacing: "0em", textAlign: "left" }}>
-										FAQ
+			<header>
+				<Box style={{ width: "100%" }} sx={{ flexGrow: 1, paddingBottom: "15px" }}>
+					<AppBar position="static" style={{ backgroundColor: "rgba(0,0,0,0)", boxShadow: "0 0 0 0" }}>
+						<Toolbar style={{ overflowX: "none", display: "flex", justifyContent: "space-between" }}>
+							<div style={{ display: "inherit" }}>
+								<Link to="/" style={{ textDecoration: "none", display: "inherit", userSelect: "none" }}>
+									<img src={NftLogo} alt="Logo" style={{ width: "63px", height: "63px", marginRight: "7px" }} />
+									<Typography style={{ fontSize: "17px", fontFamily: "Josefin Sans", lineHeight: "96%", marginTop: "19px", opacity: "86%", color: "white", whiteSpace: "nowrap" }}>
+										NFT<br/>the world!
 									</Typography>
 								</Link>
+								<div style={{ marginTop: "29px", marginLeft: "14px", display: "inherit" }}>
+									<div style={{ width: "15px", height: "0", transform: "rotate(270deg)", border: "1px solid #8d8d8d", color: "#8d8d8d", backgroundColor: "#8d8d8d", float: "left", marginRight: "14px", marginTop: "11px" }}/>
+									<Link to="/faq"  style={{ textDecoration: "none", color: "white" }}>
+										<Typography style={{ fontFamily: "Noto Sans", fontSize: "16px", fontStyle: "normal", fontWeight: "700", lineWeight: "22px", letterSpacing: "0em", textAlign: "left" }}>
+											FAQ
+										</Typography>
+									</Link>
+								</div>
 							</div>
-						</div>
-						<div style={{ display: "inherit", marginTop: "23px", fontFamily: "PT Sans !important" }}>
-							{ user
-								?
-								<>
-									{userIsAdmin && <HeaderButton color="inherit" component={Link} to="/admin" style={{ width: "80px" }}>Admin</HeaderButton>}
-									<HeaderButton color="inherit" component={Link} to="/profile" style={{ width: "80px" }}>Profile</HeaderButton>
-									<HeaderButton color="inherit" component={Link} to="/wallets">Wallets</HeaderButton>
-								</>
-								:
-								<>
-									<HeaderButton style={{ marginRight: "25px" }} component={Link} to="/login">Login</HeaderButton>
-									<HeaderButton style={{ backgroundColor: "#009C19", width: "114px" }} component={Link} to="/signup">Sign Up</HeaderButton>
-								</>
-							}
-						</div>
-					</Toolbar>
-				</AppBar>
-			</Box>
+							<div style={{ display: "inherit", marginTop: "23px", fontFamily: "PT Sans !important" }}>
+								{ user
+									?
+									<>
+										{userIsAdmin && <HeaderButton color="inherit" component={Link} to="/user/admin" style={{ width: "80px" }}>Admin</HeaderButton>}
+										<HeaderButton color="inherit" component={Link} to="/user/profile" style={{ width: "80px" }}>Profile</HeaderButton>
+										<HeaderButton color="inherit" component={Link} to="/user/wallets">Wallets</HeaderButton>
+									</>
+									:
+									<>
+										<HeaderButton style={{ marginRight: "25px" }} component={Link} to="/login">Login</HeaderButton>
+										<HeaderButton style={{ backgroundColor: "#009C19", width: "114px" }} component={Link} to="/signup">Sign Up</HeaderButton>
+									</>
+								}
+							</div>
+						</Toolbar>
+					</AppBar>
+				</Box>
+			</header>
 			{children}
 		</>
 	);

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -7,7 +7,7 @@ import { AppBar, Box, Toolbar, Typography } from "@mui/material";
 import { Link } from "react-router-dom";
 import NftLogo from "../assets/NFTTheWorldLogo.svg";
 import appwriteApi from "../api/appwriteApi";
-import HeaderButton from "./HeaderButton";
+import RoundedEdgesButton from "./RoundedEdgesButton";
 
 /**
  * Wrapper component used to display general routes in the head of the page. The routes/buttons in the header are different
@@ -52,14 +52,14 @@ export default function Header({ children, user }) {
 								{ user
 									?
 									<>
-										{userIsAdmin && <HeaderButton color="inherit" component={Link} to="/user/admin" style={{ width: "80px" }}>Admin</HeaderButton>}
-										<HeaderButton color="inherit" component={Link} to="/user/profile" style={{ width: "80px" }}>Profile</HeaderButton>
-										<HeaderButton color="inherit" component={Link} to="/user/wallets">Wallets</HeaderButton>
+										{userIsAdmin && <RoundedEdgesButton color="inherit" component={Link} to="/user/admin" style={{ width: "80px" }}>Admin</RoundedEdgesButton>}
+										<RoundedEdgesButton color="inherit" component={Link} to="/user/profile" style={{ width: "80px" }}>Profile</RoundedEdgesButton>
+										<RoundedEdgesButton color="inherit" component={Link} to="/user/wallets">Wallets</RoundedEdgesButton>
 									</>
 									:
 									<>
-										<HeaderButton style={{ marginRight: "25px" }} component={Link} to="/login">Login</HeaderButton>
-										<HeaderButton style={{ backgroundColor: "#009C19", width: "114px" }} component={Link} to="/signup">Sign Up</HeaderButton>
+										<RoundedEdgesButton style={{ marginRight: "25px" }} component={Link} to="/login">Login</RoundedEdgesButton>
+										<RoundedEdgesButton style={{ backgroundColor: "#009C19", width: "114px" }} component={Link} to="/signup">Sign Up</RoundedEdgesButton>
 									</>
 								}
 							</div>

--- a/frontend/src/components/HeaderTypography.js
+++ b/frontend/src/components/HeaderTypography.js
@@ -1,0 +1,8 @@
+import { Typography } from "@mui/material";
+import React from "react";
+
+export default function HeaderTypography(props){
+	return <Typography {...props} style={{ ...props.style, fontFamily: "Montserrat" }}>
+		{props.children}
+	</Typography>;
+}

--- a/frontend/src/components/HeaderTypography.js
+++ b/frontend/src/components/HeaderTypography.js
@@ -1,6 +1,15 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2021 Dominic Heil <d.heil@campus.tu-berlin.de>
+
 import { Typography } from "@mui/material";
 import React from "react";
 
+/**
+ * Typography used for headings. Customized with Noto Sans font. Builds up on MUI Typography.
+ * @param props any props that are passed to the MUI Typography
+ * @returns {JSX.Element}
+ * @constructor
+ */
 export default function HeaderTypography(props){
 	return <Typography {...props} style={{ ...props.style, fontFamily: "Montserrat" }}>
 		{props.children}

--- a/frontend/src/components/ParagraphTypography.js
+++ b/frontend/src/components/ParagraphTypography.js
@@ -1,6 +1,15 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2021 Dominic Heil <d.heil@campus.tu-berlin.de>
+
 import { Typography } from "@mui/material";
 import React from "react";
 
+/**
+ * Typography used for paragraphs and some headings. Customized with Noto Sans font. Builds up on MUI Typography.
+ * @param props any props that are passed to the MUI Typography
+ * @returns {JSX.Element}
+ * @constructor
+ */
 export default function ParagraphTypography(props){
 	return <Typography {...props} style={{ ...props.style, fontFamily: "Noto Sans" }}>
 		{props.children}

--- a/frontend/src/components/ParagraphTypography.js
+++ b/frontend/src/components/ParagraphTypography.js
@@ -1,0 +1,8 @@
+import { Typography } from "@mui/material";
+import React from "react";
+
+export default function ParagraphTypography(props){
+	return <Typography {...props} style={{ ...props.style, fontFamily: "Noto Sans" }}>
+		{props.children}
+	</Typography>;
+}

--- a/frontend/src/components/RoundedEdgesButton.js
+++ b/frontend/src/components/RoundedEdgesButton.js
@@ -4,6 +4,12 @@
 import { Button } from "@mui/material";
 import React from "react";
 
+/**
+ * This component implements a custom button with rounded edges. Builds up on the MUI Button.
+ * @param props any props that will be passed to the MUI Button component that is customized.
+ * @returns {JSX.Element}
+ * @constructor
+ */
 export default function RoundedEdgesButton(props){
 	return <Button
 		{...props}

--- a/frontend/src/components/RoundedEdgesButton.js
+++ b/frontend/src/components/RoundedEdgesButton.js
@@ -4,7 +4,7 @@
 import { Button } from "@mui/material";
 import React from "react";
 
-export default function HeaderButton(props){
+export default function RoundedEdgesButton(props){
 	return <Button
 		{...props}
 		style={{ ...props.style, borderRadius: "27px", height: "40px", textTransform: "none" }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,9 +1,14 @@
  /* SPDX-License-Identifier: MIT */
  /* SPDX-FileCopyrightText: 2021 Dominic Heil <d.heil@campus.tu-berlin.de> */
 
- @import url('http://fonts.googleapis.com/css?family=Noto+Sans:400,700,400italic,700italic&subset=latin,latin-ext');
- @import url('http://fonts.googleapis.com/css?family=Josefin+Sans:400,700,400italic,700italic&subset=latin,latin-ext');
- @import url('http://fonts.googleapis.com/css?family=PT+Sans:400,700,400italic,700italic&subset=latin,latin-ext');
+@import url('http://fonts.googleapis.com/css?family=Noto+Sans:400,700,400italic,700italic&subset=latin,latin-ext');
+@import url('http://fonts.googleapis.com/css?family=Josefin+Sans:400,700,400italic,700italic&subset=latin,latin-ext');
+@import url('http://fonts.googleapis.com/css?family=PT+Sans:400,700,400italic,700italic&subset=latin,latin-ext');
+@import url('http://fonts.googleapis.com/css?family=Montserrat:400,700,400italic,700italic&subset=latin,latin-ext');
+
+ html {
+	background-color: #1C1C1C;
+}
 
 body {
 	margin: 0;

--- a/frontend/src/pages/AdminPage.js
+++ b/frontend/src/pages/AdminPage.js
@@ -5,11 +5,12 @@ import CenterFlexBox from "../components/CenterFlexBox";
 import {
 	Accordion, AccordionDetails,
 	AccordionSummary,
-	Typography,
 } from "@mui/material";
 import React from "react";
 import EditAdminTeam from "../components/EditAdminTeam";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ParagraphTypography from "../components/ParagraphTypography";
+import HeaderTypography from "../components/HeaderTypography";
 
 /**
  * Page for use of admins to invite/remove other admins, post new announcements, schedule new drops and other admin tasks.
@@ -19,13 +20,13 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 export default function AdminPage({ user }) {
 	return <CenterFlexBox>
 		<div style={{ width: "100%" }}>
-			<Typography component="div" variant="h4" gutterBottom>Admin Area</Typography>
+			<HeaderTypography component="div" variant="h4" gutterBottom>Admin Area</HeaderTypography>
 			<Accordion>
 				<AccordionSummary
 					expandIcon={<ExpandMoreIcon />}
 					aria-controls="panel1a-content"
 					id="panel1a-header">
-					<Typography>Edit admin team</Typography>
+					<ParagraphTypography>Edit admin team</ParagraphTypography>
 				</AccordionSummary>
 				<AccordionDetails>
 					<EditAdminTeam user={user}/>
@@ -36,12 +37,12 @@ export default function AdminPage({ user }) {
 					expandIcon={<ExpandMoreIcon />}
 					aria-controls="panel2a-content"
 					id="panel2a-header">
-					<Typography>Write new announcement</Typography>
+					<ParagraphTypography>Write new announcement</ParagraphTypography>
 				</AccordionSummary>
 				<AccordionDetails>
-					<Typography>
+					<ParagraphTypography>
 						To be added.
-					</Typography>
+					</ParagraphTypography>
 				</AccordionDetails>
 			</Accordion>
 			<Accordion>
@@ -49,12 +50,12 @@ export default function AdminPage({ user }) {
 					expandIcon={<ExpandMoreIcon />}
 					aria-controls="panel3a-content"
 					id="panel3a-header">
-					<Typography>Schedule Drop</Typography>
+					<ParagraphTypography>Schedule Drop</ParagraphTypography>
 				</AccordionSummary>
 				<AccordionDetails>
-					<Typography>
+					<ParagraphTypography>
 						SOON.
-					</Typography>
+					</ParagraphTypography>
 				</AccordionDetails>
 			</Accordion>
 		</div>

--- a/frontend/src/pages/ChangePasswordPage.js
+++ b/frontend/src/pages/ChangePasswordPage.js
@@ -2,17 +2,16 @@
 // SPDX-FileCopyrightText: 2021 Dominic Heil <d.heil@campus.tu-berlin.de>
 
 import * as React from "react";
-import Avatar from "@mui/material/Avatar";
-import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
-import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
-import Typography from "@mui/material/Typography";
 import CenterFlexBox from "../components/CenterFlexBox";
 import appwriteApi from "../api/appwriteApi";
 import { useState } from "react";
 import { Alert } from "@mui/material";
+import { inputFieldStyle } from "../assets/jss/InputFieldJSS";
+import HeaderButton from "../components/HeaderButton";
+import ParagraphTypography from "../components/ParagraphTypography";
 
 /**
  * Page used for changing the password of a user.
@@ -32,26 +31,24 @@ export default function ChangePasswordPage() {
 
 	return (
 		<CenterFlexBox>
-			<Avatar sx={{ m: 1, bgcolor: "secondary.main" }}>
-				<LockOutlinedIcon />
-			</Avatar>
-			<Typography component="h1" variant="h5">
-				Change Password
-			</Typography>
+			<ParagraphTypography component="h1" variant="h5" style={{ paddingBottom: "29px" }}>
+				Password Change
+			</ParagraphTypography>
 			<>
 				<Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
 					{passwordWasChanged ?
-						<Typography>
+						<ParagraphTypography>
 								Your password was changed!
-						</Typography>
+						</ParagraphTypography>
 						:
 						<>
 							<Grid container spacing={2}>
 								<Grid item xs={12}>
-									<Typography>Enter your old and a new password!</Typography>
+									<ParagraphTypography>Enter your old and a new password.</ParagraphTypography>
 								</Grid>
 								<Grid item xs={12}>
 									<TextField
+										sx = {{ ...inputFieldStyle }}
 										required
 										fullWidth
 										name="oldPassword"
@@ -62,6 +59,7 @@ export default function ChangePasswordPage() {
 								</Grid>
 								<Grid item xs={12}>
 									<TextField
+										sx = {{ ...inputFieldStyle, marginBottom: 0 }}
 										required
 										fullWidth
 										name="newPassword"
@@ -73,13 +71,16 @@ export default function ChangePasswordPage() {
 								</Grid>
 								{errorMessage !== "" && <Grid item xs={12}><Alert severity="error">{errorMessage}</Alert></Grid>}
 							</Grid>
-							<Button
-								type="submit"
-								fullWidth
-								variant="contained"
-								sx={{ mt: 3, mb: 2 }}>
+
+							<div style={{ overflowX: "none", display: "flex", paddingTop: "18px", paddingBottom: "18.5px" }}>
+								<HeaderButton
+									type="submit"
+									fullWidth
+									variant="contained"
+									style={{ backgroundColor: "#008425", width: "170px", marginLeft: "auto" }} >
 									Change password
-							</Button>
+								</HeaderButton>
+							</div>
 						</>
 					}
 				</Box>

--- a/frontend/src/pages/ChangePasswordPage.js
+++ b/frontend/src/pages/ChangePasswordPage.js
@@ -10,7 +10,7 @@ import appwriteApi from "../api/appwriteApi";
 import { useState } from "react";
 import { Alert } from "@mui/material";
 import { inputFieldStyle } from "../assets/jss/InputFieldJSS";
-import HeaderButton from "../components/HeaderButton";
+import RoundedEdgesButton from "../components/RoundedEdgesButton";
 import ParagraphTypography from "../components/ParagraphTypography";
 
 /**
@@ -73,13 +73,13 @@ export default function ChangePasswordPage() {
 							</Grid>
 
 							<div style={{ overflowX: "none", display: "flex", paddingTop: "18px", paddingBottom: "18.5px" }}>
-								<HeaderButton
+								<RoundedEdgesButton
 									type="submit"
 									fullWidth
 									variant="contained"
 									style={{ backgroundColor: "#008425", width: "170px", marginLeft: "auto" }} >
 									Change password
-								</HeaderButton>
+								</RoundedEdgesButton>
 							</div>
 						</>
 					}

--- a/frontend/src/pages/EmailConfirmPage.js
+++ b/frontend/src/pages/EmailConfirmPage.js
@@ -4,7 +4,7 @@
 import React, { useEffect, useState } from "react";
 import appwriteApi from "../api/appwriteApi";
 import CenterFlexBox from "../components/CenterFlexBox";
-import { Typography } from "@mui/material";
+import ParagraphTypography from "../components/ParagraphTypography";
 
 /**
  * Page used to confirm the email of a user. The URL query params `userID` and `secret` need to be specified in order
@@ -31,9 +31,9 @@ export default function EmailConfirmPage() {
 	return <CenterFlexBox>
 		{wasConfirmed
 			?
-			<Typography>Email confirmed successfully.</Typography>
+			<ParagraphTypography>Email confirmed successfully.</ParagraphTypography>
 			:
-			<Typography>Was not able to confirm email.</Typography>
+			<ParagraphTypography>Was not able to confirm email.</ParagraphTypography>
 		}
 
 	</CenterFlexBox>;

--- a/frontend/src/pages/JoinTeamPage.js
+++ b/frontend/src/pages/JoinTeamPage.js
@@ -4,7 +4,7 @@
 import React, { useEffect, useState } from "react";
 import appwriteApi from "../api/appwriteApi";
 import CenterFlexBox from "../components/CenterFlexBox";
-import { Typography } from "@mui/material";
+import ParagraphTypography from "../components/ParagraphTypography";
 
 /**
  * Page used to accept invitation to join a team. The URL query params `membershipId`, `userID`, `teamId` and `secret`
@@ -40,9 +40,9 @@ export default function JoinTeamPage({ user }) {
 	return <CenterFlexBox>
 		{wasAccepted
 			?
-			<Typography>Successfully joined the team.</Typography>
+			<ParagraphTypography>Successfully joined the team.</ParagraphTypography>
 			:
-			<Typography>Was not able to join team. {user === null && <>It seems like you are not logged in. Login and then try accepting the invitation again!</>}</Typography>
+			<ParagraphTypography>Was not able to join team. {user === null && <>It seems like you are not logged in. Login and then try accepting the invitation again!</>}</ParagraphTypography>
 		}
 
 	</CenterFlexBox>;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -14,7 +14,7 @@ import { useState } from "react";
 import { Alert, Divider } from "@mui/material";
 import useChangeRoute from "../hooks/useChangeRoute";
 import { inputFieldStyle } from "../assets/jss/InputFieldJSS";
-import HeaderButton from "../components/HeaderButton";
+import RoundedEdgesButton from "../components/RoundedEdgesButton";
 import ParagraphTypography from "../components/ParagraphTypography";
 
 /**
@@ -85,13 +85,13 @@ export default function Login({ user, setUser }) {
 						sx={{ "& .MuiSvgIcon-root": { fontSize: 21, borderRadius: "4px", color: "#FFFFFF99" } }}
 						label={<ParagraphTypography style={{ fontSize: "15px" }}>Remember me</ParagraphTypography>}
 					/>
-					<HeaderButton
+					<RoundedEdgesButton
 						type="submit"
 						fullWidth
 						variant="contained"
 						style={{ backgroundColor: "#008425", width: "132px" }} >
 						Sign In
-					</HeaderButton>
+					</RoundedEdgesButton>
 				</div>
 				<Divider style={{ backgroundColor: "rgba(255,255,255,0.2)" }}/>
 				<Grid container style={{ alignItems: "center", height: "37px" }}>

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -2,21 +2,20 @@
 // SPDX-FileCopyrightText: 2021 Dominic Heil <d.heil@campus.tu-berlin.de>
 
 import * as React from "react";
-import Avatar from "@mui/material/Avatar";
-import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Checkbox from "@mui/material/Checkbox";
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
-import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
-import Typography from "@mui/material/Typography";
 import { Link } from "react-router-dom";
 import CenterFlexBox from "../components/CenterFlexBox";
 import appwriteApi from "../api/appwriteApi";
 import { useState } from "react";
-import { Alert } from "@mui/material";
+import { Alert, Divider } from "@mui/material";
 import useChangeRoute from "../hooks/useChangeRoute";
+import { inputFieldStyle } from "../assets/jss/InputFieldJSS";
+import HeaderButton from "../components/HeaderButton";
+import ParagraphTypography from "../components/ParagraphTypography";
 
 /**
  * Page used to login
@@ -48,24 +47,28 @@ export default function Login({ user, setUser }) {
 	}
 	return (
 		<CenterFlexBox>
-			<Avatar sx={{ m: 1, bgcolor: "secondary.main" }}>
-				<LockOutlinedIcon />
-			</Avatar>
-			<Typography component="h1" variant="h5">
-				Login
-			</Typography>
+			<ParagraphTypography component="h1" variant="h5" style={{ paddingBottom: "29px" }}>
+				Sign in to NFT The world!
+			</ParagraphTypography>
+			<div style={{ marginRight: "auto", marginBottom: "-13px" }}>
+				<ParagraphTypography variant="p" style={{ fontSize: "15px" }}>
+					Required fields have an asterisk: *
+				</ParagraphTypography>
+			</div>
 			<Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
 				<TextField
+					sx = {{ ...inputFieldStyle }}
 					margin="normal"
 					required
 					fullWidth
 					id="email"
-					label="Email Address"
+					label="Email"
 					name="email"
 					autoComplete="email"
 					autoFocus
 				/>
 				<TextField
+					sx = {{ ...inputFieldStyle, marginBottom: 0 }}
 					margin="normal"
 					required
 					fullWidth
@@ -75,31 +78,35 @@ export default function Login({ user, setUser }) {
 					id="password"
 					autoComplete="current-password"
 				/>
-				<FormControlLabel
-					control={<Checkbox value="remember" color="primary" />}
-					label="Remember me"
-				/>
-				{errorMessage !== "" && <Grid item xs={12}><Alert severity="error">{errorMessage}</Alert></Grid>}
-				<Button
-					type="submit"
-					fullWidth
-					variant="contained"
-					sx={{ mt: 3, mb: 2 }}>
-					Sign In
-				</Button>
-				<Grid container>
+				{errorMessage !== "" && <Grid item xs={12} style={{ paddingTop: "24px" }}><Alert severity="error">{errorMessage}</Alert></Grid>}
+				<div style={{ overflowX: "none", display: "flex", justifyContent: "space-between", paddingTop: "18px", paddingBottom: "18.5px" }}>
+					<FormControlLabel
+						control={<Checkbox value="remember" color="primary" size="medium" style={{ borderRadius: "4px" }} />}
+						sx={{ "& .MuiSvgIcon-root": { fontSize: 21, borderRadius: "4px", color: "#FFFFFF99" } }}
+						label={<ParagraphTypography style={{ fontSize: "15px" }}>Remember me</ParagraphTypography>}
+					/>
+					<HeaderButton
+						type="submit"
+						fullWidth
+						variant="contained"
+						style={{ backgroundColor: "#008425", width: "132px" }} >
+						Sign In
+					</HeaderButton>
+				</div>
+				<Divider style={{ backgroundColor: "rgba(255,255,255,0.2)" }}/>
+				<Grid container style={{ alignItems: "center", height: "37px" }}>
 					<Grid item xs>
-						<Link to="/requestPasswordReset" >
-							<Typography variant="body2" color="white" style={{ textDecorationLine: "underline" }}>
+						<Link to="/requestPasswordReset" style={{ textDecorationLine: "none" }}>
+							<ParagraphTypography variant="body2" color="#008425" style={{ fontSize: "14px" }}>
 								Forgot password?
-							</Typography>
+							</ParagraphTypography>
 						</Link>
 					</Grid>
 					<Grid item>
-						<Link to="/signup" >
-							<Typography variant="body2" color="white" style={{ textDecorationLine: "underline" }}>
-								Don&apos;t have an account? Sign Up
-							</Typography>
+						<Link to="/signup" style={{ textDecorationLine: "none" }}>
+							<ParagraphTypography variant="body2" color="#008425" style={{ fontSize: "14px" }}>
+								Don&apos;t have an account?
+							</ParagraphTypography>
 						</Link>
 					</Grid>
 				</Grid>

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -50,7 +50,7 @@ export default function Profile({ user, setUser }) {
 							</TableRow>
 							<TableRow>
 								<TableCell style={{ color: "white", borderBottom: "none" }}>Password</TableCell>
-								<TableCell style={{ color: "white", borderBottom: "none" }}><Button variant="outlined" onClick={() => changeRoute("/changePassword")}>Change password</Button></TableCell>
+								<TableCell style={{ color: "white", borderBottom: "none" }}><Button variant="outlined" onClick={() => changeRoute("/user/changePassword")}>Change password</Button></TableCell>
 							</TableRow>
 						</TableBody>
 					</Table>

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -58,9 +58,10 @@ export default function Profile({ user, setUser }) {
 			</Grid>
 			<Grid item>
 				<Button
-					variant="outlined" style={{ color: "red" }} onClick={() => appwriteApi.deleteCurrentSession().then(() =>
-						setUser(null)
-					)}>Logout</Button>
+					variant="outlined" style={{ color: "red" }} onClick={() => appwriteApi.deleteCurrentSession().then(() => {
+						setUser(null);
+						changeRoute("/");
+					})}>Logout</Button>
 			</Grid>
 		</Grid>
 

--- a/frontend/src/pages/RequestPasswordResetPage.js
+++ b/frontend/src/pages/RequestPasswordResetPage.js
@@ -12,7 +12,7 @@ import { useState } from "react";
 import { Alert, Divider } from "@mui/material";
 import useChangeRoute from "../hooks/useChangeRoute";
 import { inputFieldStyle } from "../assets/jss/InputFieldJSS";
-import HeaderButton from "../components/HeaderButton";
+import RoundedEdgesButton from "../components/RoundedEdgesButton";
 import ParagraphTypography from "../components/ParagraphTypography";
 
 
@@ -62,13 +62,13 @@ export default function RequestPasswordResetPage({ user }) {
 					/>
 					{errorMessage !== "" && <Grid item xs={12} style={{ paddingTop: "18px" }}><Alert severity="error">{errorMessage}</Alert></Grid>}
 					<div style={{ overflowX: "none", display: "flex", paddingTop: "18px", paddingBottom: "18.5px" }}>
-						<HeaderButton
+						<RoundedEdgesButton
 							type="submit"
 							fullWidth
 							variant="contained"
 							style={{ backgroundColor: "#008425", width: "250px", marginLeft: "auto" }} >
 							Request password reset
-						</HeaderButton>
+						</RoundedEdgesButton>
 					</div>
 					<Divider style={{ backgroundColor: "rgba(255,255,255,0.2)" }}/>
 					<Grid container style={{ alignItems: "center", height: "37px" }}>

--- a/frontend/src/pages/RequestPasswordResetPage.js
+++ b/frontend/src/pages/RequestPasswordResetPage.js
@@ -55,7 +55,7 @@ export default function RequestPasswordResetPage({ user }) {
 						required
 						fullWidth
 						id="email"
-						label="Email Address"
+						label="Email"
 						name="email"
 						autoComplete="email"
 						autoFocus

--- a/frontend/src/pages/RequestPasswordResetPage.js
+++ b/frontend/src/pages/RequestPasswordResetPage.js
@@ -2,19 +2,18 @@
 // SPDX-FileCopyrightText: 2021 Dominic Heil <d.heil@campus.tu-berlin.de>
 
 import * as React from "react";
-import Avatar from "@mui/material/Avatar";
-import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
-import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
-import Typography from "@mui/material/Typography";
 import { Link } from "react-router-dom";
 import CenterFlexBox from "../components/CenterFlexBox";
 import appwriteApi from "../api/appwriteApi";
 import { useState } from "react";
-import { Alert } from "@mui/material";
+import { Alert, Divider } from "@mui/material";
 import useChangeRoute from "../hooks/useChangeRoute";
+import { inputFieldStyle } from "../assets/jss/InputFieldJSS";
+import HeaderButton from "../components/HeaderButton";
+import ParagraphTypography from "../components/ParagraphTypography";
 
 
 /**
@@ -40,22 +39,18 @@ export default function RequestPasswordResetPage({ user }) {
 	}
 	return (
 		<CenterFlexBox>
-			<Avatar sx={{ m: 1, bgcolor: "secondary.main" }}>
-				<LockOutlinedIcon />
-			</Avatar>
-			<Typography component="h1" variant="h5">
+			<ParagraphTypography component="h1" variant="h5" style={{ paddingBottom: "29px" }}>
 				Request Password Reset
-			</Typography>
+			</ParagraphTypography>
 			{resetWasRequested ?
 				<Box sx={{ m: 4 }} >
-					<Alert severity="info">
-						You will receive an email shortly explaining how you can reset your password.
-					</Alert>
+					<ParagraphTypography>You will receive an email shortly explaining how you can reset your password.</ParagraphTypography>
 				</Box>
 				:
 				<Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
-					<Typography>Enter your email and click the button below to request a password reset</Typography>
+					<ParagraphTypography>Enter your email and click the button below to request a password reset:</ParagraphTypography>
 					<TextField
+						sx = {{ ...inputFieldStyle, marginBottom: 0 }}
 						margin="normal"
 						required
 						fullWidth
@@ -65,29 +60,23 @@ export default function RequestPasswordResetPage({ user }) {
 						autoComplete="email"
 						autoFocus
 					/>
-					<>
-						{errorMessage !== "" && <Grid item xs={12}><Alert severity="error">{errorMessage}</Alert></Grid>}
-						<Button
+					{errorMessage !== "" && <Grid item xs={12} style={{ paddingTop: "18px" }}><Alert severity="error">{errorMessage}</Alert></Grid>}
+					<div style={{ overflowX: "none", display: "flex", paddingTop: "18px", paddingBottom: "18.5px" }}>
+						<HeaderButton
 							type="submit"
 							fullWidth
 							variant="contained"
-							sx={{ mt: 3, mb: 2 }}>
+							style={{ backgroundColor: "#008425", width: "250px", marginLeft: "auto" }} >
 							Request password reset
-						</Button>
-					</>
-					<Grid container>
-						<Grid item xs>
-							<Link to="/login" >
-								<Typography variant="body2" color="white" style={{ textDecorationLine: "underline" }}>
-								Remember your password? Login
-								</Typography>
-							</Link>
-						</Grid>
-						<Grid item>
-							<Link to="/signup" >
-								<Typography variant="body2" color="white" style={{ textDecorationLine: "underline" }}>
-								Don&apos;t have an account? Sign Up
-								</Typography>
+						</HeaderButton>
+					</div>
+					<Divider style={{ backgroundColor: "rgba(255,255,255,0.2)" }}/>
+					<Grid container style={{ alignItems: "center", height: "37px" }}>
+						<Grid item style={{ marginLeft: "auto" }}>
+							<Link to="/login" style={{ textDecorationLine: "none" }}>
+								<ParagraphTypography variant="body2" color="#008425" style={{ fontSize: "14px" }}>
+									Remember your password? Sign in
+								</ParagraphTypography>
 							</Link>
 						</Grid>
 					</Grid>

--- a/frontend/src/pages/ResetPasswordPage.js
+++ b/frontend/src/pages/ResetPasswordPage.js
@@ -2,19 +2,18 @@
 // SPDX-FileCopyrightText: 2021 Dominic Heil <d.heil@campus.tu-berlin.de>
 
 import * as React from "react";
-import Avatar from "@mui/material/Avatar";
-import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
-import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
-import Typography from "@mui/material/Typography";
 import { Link } from "react-router-dom";
 import CenterFlexBox from "../components/CenterFlexBox";
 import appwriteApi from "../api/appwriteApi";
 import { useState } from "react";
 import { Alert } from "@mui/material";
 import useChangeRoute from "../hooks/useChangeRoute";
+import ParagraphTypography from "../components/ParagraphTypography";
+import { inputFieldStyle } from "../assets/jss/InputFieldJSS";
+import HeaderButton from "../components/HeaderButton";
 
 /**
  * Page used to reset the password of a user. The URL query params `userId` and `secret`
@@ -46,20 +45,18 @@ export default function ResetPasswordPage({ user }) {
 	}
 	return (
 		<CenterFlexBox>
-			<Avatar sx={{ m: 1, bgcolor: "secondary.main" }}>
-				<LockOutlinedIcon />
-			</Avatar>
-			<Typography component="h1" variant="h5">
+			<ParagraphTypography component="h1" variant="h5" style={{ paddingBottom: "29px" }}>
 				Password Reset
-			</Typography>
+			</ParagraphTypography>
 			{
 				passwordWasChanged
 					?
-
 					<Box sx={{ mt: 1 }}>
 						<Grid container spacing={2}>
 							<Grid item xs={12}>
-								Your password was changed! <Link to="/login">Login</Link>
+								<ParagraphTypography>
+									Your password was changed! <Link to="/login" style={{ textDecorationLine: "none", color:"#008425" }}>Login</Link>
+								</ParagraphTypography>
 							</Grid>
 						</Grid>
 					</Box>
@@ -67,19 +64,22 @@ export default function ResetPasswordPage({ user }) {
 					<>
 						{paramsMissing ?
 							<Box sx={{ m: 4 }} >
-								<Typography component="p" variant="p">
-								If you would like to reset your password, go to the <Link style={{ color:"white" }} to="/requestPasswordReset">password reset page</Link>.
-								</Typography>
+								<ParagraphTypography component="p" variant="p">
+									If you would like to reset your password, go to the <Link style={{ color:"white" }} to="/requestPasswordReset">password reset page</Link>.
+								</ParagraphTypography>
 							</Box>
 							:
 							<Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
 								<Grid container spacing={2}>
 
 									<Grid item xs={12}>
-										<Typography>Enter a new password!</Typography>
+										<ParagraphTypography variant="p" style={{ fontSize: "15px" }}>
+											Enter a new password!
+										</ParagraphTypography>
 									</Grid>
 									<Grid item xs={12}>
 										<TextField
+											sx = {{ ...inputFieldStyle, marginBottom: 0 }}
 											required
 											fullWidth
 											name="password"
@@ -91,6 +91,7 @@ export default function ResetPasswordPage({ user }) {
 									</Grid>
 									<Grid item xs={12}>
 										<TextField
+											sx = {{ ...inputFieldStyle, marginBottom: 0 }}
 											required
 											fullWidth
 											name="passwordAgain"
@@ -102,13 +103,15 @@ export default function ResetPasswordPage({ user }) {
 									</Grid>
 									{errorMessage !== "" && <Grid item xs={12}><Alert severity="error">{errorMessage}</Alert></Grid>}
 								</Grid>
-								<Button
-									type="submit"
-									fullWidth
-									variant="contained"
-									sx={{ mt: 3, mb: 2 }}>
-					Change password
-								</Button>
+								<div style={{ overflowX: "none", display: "flex", paddingTop: "18px", paddingBottom: "18.5px" }}>
+									<HeaderButton
+										type="submit"
+										fullWidth
+										variant="contained"
+										style={{ backgroundColor: "#008425", width: "170px", marginLeft: "auto" }} >
+										Change password
+									</HeaderButton>
+								</div>
 							</Box>
 						}
 					</>

--- a/frontend/src/pages/ResetPasswordPage.js
+++ b/frontend/src/pages/ResetPasswordPage.js
@@ -13,7 +13,7 @@ import { Alert } from "@mui/material";
 import useChangeRoute from "../hooks/useChangeRoute";
 import ParagraphTypography from "../components/ParagraphTypography";
 import { inputFieldStyle } from "../assets/jss/InputFieldJSS";
-import HeaderButton from "../components/HeaderButton";
+import RoundedEdgesButton from "../components/RoundedEdgesButton";
 
 /**
  * Page used to reset the password of a user. The URL query params `userId` and `secret`
@@ -104,13 +104,13 @@ export default function ResetPasswordPage({ user }) {
 									{errorMessage !== "" && <Grid item xs={12}><Alert severity="error">{errorMessage}</Alert></Grid>}
 								</Grid>
 								<div style={{ overflowX: "none", display: "flex", paddingTop: "18px", paddingBottom: "18.5px" }}>
-									<HeaderButton
+									<RoundedEdgesButton
 										type="submit"
 										fullWidth
 										variant="contained"
 										style={{ backgroundColor: "#008425", width: "170px", marginLeft: "auto" }} >
 										Change password
-									</HeaderButton>
+									</RoundedEdgesButton>
 								</div>
 							</Box>
 						}

--- a/frontend/src/pages/SignUp.js
+++ b/frontend/src/pages/SignUp.js
@@ -2,18 +2,17 @@
 // SPDX-FileCopyrightText: 2021 Dominic Heil <d.heil@campus.tu-berlin.de>
 
 import * as React from "react";
-import Avatar from "@mui/material/Avatar";
-import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
-import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
-import Typography from "@mui/material/Typography";
 import { Link } from "react-router-dom";
 import CenterFlexBox from "../components/CenterFlexBox";
 import appwriteApi from "../api/appwriteApi";
 import { useState } from "react";
-import { Alert } from "@mui/material";
+import { Alert, Divider } from "@mui/material";
+import { inputFieldStyle } from "../assets/jss/InputFieldJSS";
+import HeaderButton from "../components/HeaderButton";
+import ParagraphTypography from "../components/ParagraphTypography";
 
 
 /**
@@ -39,7 +38,7 @@ export default function SignUp() {
 			})
 			.catch(err => {
 				if (err.response.code === 409){
-					setErrorMessage(<><Typography>{err.message} <Link to="/login">Login</Link></Typography></>);
+					setErrorMessage(<ParagraphTypography>{err.message}. <Link to="/login" style={{ color:"#008425" }}>Sign in</Link></ParagraphTypography>);
 				} else {
 					setErrorMessage(err.message);
 				}
@@ -48,72 +47,82 @@ export default function SignUp() {
 
 	return (
 		<CenterFlexBox>
-			<Avatar sx={{ m: 1, bgcolor: "secondary.main" }}>
-				<LockOutlinedIcon />
-			</Avatar>
-			<Typography component="h1" variant="h5">
-				Sign up
-			</Typography>
+			<ParagraphTypography component="h1" variant="h5" style={{ paddingBottom: "29px" }}>
+				Sign up to NFT The world!
+			</ParagraphTypography>
 			{
 				registrationComplete
 					?
-					<>
+					<ParagraphTypography>
 						We sent you a confirmation email. Please confirm your registration!
-					</>
+					</ParagraphTypography>
 					:
-					<Box component="form" noValidate onSubmit={handleSubmit} sx={{ mt: 3 }}>
-						<Grid container spacing={2}>
-							<Grid item xs={12}>
-								<TextField
-									autoComplete="username"
-									name="username"
-									required
+					<>
+						<div style={{ marginRight: "auto", marginBottom: "-13px" }}>
+							<ParagraphTypography variant="p" 	style={{ fontSize: "15px" }}>
+								Required fields have an asterisk: *
+							</ParagraphTypography>
+						</div>
+						<Box component="form" noValidate onSubmit={handleSubmit} sx={{ mt: 3 }}>
+							<Grid container spacing={2}>
+								<Grid item xs={12}>
+									<TextField
+										sx = {{ ...inputFieldStyle }}
+										autoComplete="username"
+										name="username"
+										required
+										fullWidth
+										id="username"
+										label="Username"
+										autoFocus
+									/>
+								</Grid>
+								<Grid item xs={12}>
+									<TextField
+										sx = {{ ...inputFieldStyle }}
+										required
+										fullWidth
+										id="email"
+										label="Email Address"
+										name="email"
+										autoComplete="email"
+									/>
+								</Grid>
+								<Grid item xs={12}>
+									<TextField
+										sx = {{ ...inputFieldStyle, marginBottom: 0 }}
+										required
+										fullWidth
+										name="password"
+										label="Password"
+										type="password"
+										id="password"
+										autoComplete="new-password"
+									/>
+								</Grid>
+								{errorMessage !== "" && <Grid item xs={12}><Alert severity="error">{errorMessage}</Alert></Grid>}
+							</Grid>
+							<div style={{ overflowX: "none", display: "flex", paddingTop: "18px", paddingBottom: "18.5px" }}>
+								<HeaderButton
+									type="submit"
 									fullWidth
-									id="username"
-									label="Username"
-									autoFocus
-								/>
+									variant="contained"
+									style={{ backgroundColor: "#008425", width: "132px", marginLeft: "auto" }} >
+									Sign Up
+								</HeaderButton>
+							</div>
+							<Divider style={{ backgroundColor: "rgba(255,255,255,0.2)" }}/>
+							<Grid container style={{ alignItems: "center", height: "37px" }}>
+								<Grid item style={{ marginLeft: "auto" }}>
+									<Link to="/login" style={{ textDecorationLine: "none" }}>
+										<ParagraphTypography variant="body2" color="#008425" style={{ fontSize: "14px" }}>
+											Already have an account?
+										</ParagraphTypography>
+									</Link>
+								</Grid>
 							</Grid>
-							<Grid item xs={12}>
-								<TextField
-									required
-									fullWidth
-									id="email"
-									label="Email Address"
-									name="email"
-									autoComplete="email"
-								/>
-							</Grid>
-							<Grid item xs={12}>
-								<TextField
-									required
-									fullWidth
-									name="password"
-									label="Password"
-									type="password"
-									id="password"
-									autoComplete="new-password"
-								/>
-							</Grid>
-							{errorMessage !== "" && <Grid item xs={12}><Alert severity="error">{errorMessage}</Alert></Grid>}
-						</Grid>
-						<Button
-							type="submit"
-							fullWidth
-							variant="contained"
-							sx={{ mt: 3, mb: 2 }}>
-							Sign Up
-						</Button>
-						<Grid container justifyContent="flex-end">
-							<Grid item>
-								<Link to="/login" >
-									<Typography variant="body2" style={{ textDecorationLine: "underline" }}>
-										Already have an account? Sign in
-									</Typography>
-								</Link>
-							</Grid>
-						</Grid>
-					</Box>
+						</Box>
+					</>
 			}
 		</CenterFlexBox>
 	);

--- a/frontend/src/pages/SignUp.js
+++ b/frontend/src/pages/SignUp.js
@@ -11,7 +11,7 @@ import appwriteApi from "../api/appwriteApi";
 import { useState } from "react";
 import { Alert, Divider } from "@mui/material";
 import { inputFieldStyle } from "../assets/jss/InputFieldJSS";
-import HeaderButton from "../components/HeaderButton";
+import RoundedEdgesButton from "../components/RoundedEdgesButton";
 import ParagraphTypography from "../components/ParagraphTypography";
 
 
@@ -103,13 +103,13 @@ export default function SignUp() {
 								{errorMessage !== "" && <Grid item xs={12}><Alert severity="error">{errorMessage}</Alert></Grid>}
 							</Grid>
 							<div style={{ overflowX: "none", display: "flex", paddingTop: "18px", paddingBottom: "18.5px" }}>
-								<HeaderButton
+								<RoundedEdgesButton
 									type="submit"
 									fullWidth
 									variant="contained"
 									style={{ backgroundColor: "#008425", width: "132px", marginLeft: "auto" }} >
 									Sign Up
-								</HeaderButton>
+								</RoundedEdgesButton>
 							</div>
 							<Divider style={{ backgroundColor: "rgba(255,255,255,0.2)" }}/>
 							<Grid container style={{ alignItems: "center", height: "37px" }}>

--- a/frontend/src/pages/SignUp.js
+++ b/frontend/src/pages/SignUp.js
@@ -83,7 +83,7 @@ export default function SignUp() {
 										required
 										fullWidth
 										id="email"
-										label="Email Address"
+										label="Email"
 										name="email"
 										autoComplete="email"
 									/>


### PR DESCRIPTION
This PR implements the designs of the login, signup and all password reset/change/reqeust pages.

Some screenshots:
![image](https://user-images.githubusercontent.com/58464184/143384373-23bcedce-3b1a-4cdf-8cdc-524c3707cdfd.png)
Empty fields.

![image](https://user-images.githubusercontent.com/58464184/143384400-aaebe77f-6549-4c9d-8a06-391d58f92506.png)
Focus in the Email field.

![image](https://user-images.githubusercontent.com/58464184/143384431-3309b900-c147-46c5-9001-a0babedf72ea.png)
![image](https://user-images.githubusercontent.com/58464184/143384550-cc5ae215-4a1c-4f24-b2eb-c06e7cfb6374.png)
![image](https://user-images.githubusercontent.com/58464184/143384598-72d668bf-014c-42d5-be03-b99d6e230f68.png)
