### PR TITLE
Fix announcement issues

### DIFF
--- a/backend/database-collection-schemas/createAnnouncementCollection.py
+++ b/backend/database-collection-schemas/createAnnouncementCollection.py
@@ -94,6 +94,20 @@ try:
                 "required": True,
                 "array": False,
             },
+            {
+                "label": "creator",
+                "key": "creator",
+                "type": "text",
+                "required": True,
+                "array": False,
+            },
+            {
+                "label": "imageID",
+                "key": "imageID",
+                "type": "numeric",
+                "required": False,
+                "array": False,
+            },
         ],
     )
     print(createCollectionResult)
@@ -124,6 +138,7 @@ for d in data:
                 "updated_at": d[0],
                 "title": d[1],
                 "content": d[2],
+                "creator": d[3],
             },
         )
     except Exception as e:

--- a/backend/database-collection-schemas/createAnnouncementCollection.py
+++ b/backend/database-collection-schemas/createAnnouncementCollection.py
@@ -140,6 +140,8 @@ for d in data:
                 "content": d[2],
                 "creator": d[3],
             },
+            read=["*"],
+            write=["team:Admins"],
         )
     except Exception as e:
         print(e)

--- a/frontend/src/pages/AdminPage.js
+++ b/frontend/src/pages/AdminPage.js
@@ -31,7 +31,7 @@ export default function AdminPage({ user }) {
 	}, []);
 
 	return <CenterFlexBox>
-		<divs style={{ width: "100%" }}>
+		<div style={{ width: "100%" }}>
 			<HeaderTypography component="div" variant="h4" gutterBottom>Admin Area</HeaderTypography>
 
 			<HeaderTypography component="div" variant="h5" gutterBottom >General</HeaderTypography>
@@ -97,7 +97,7 @@ export default function AdminPage({ user }) {
 					<EditContractTeam user={user}/>
 				</AccordionDetails>
 			</Accordion>
-		</divs>
+		</div>
 
 	</CenterFlexBox>;
 

--- a/frontend/src/pages/FaqPage.js
+++ b/frontend/src/pages/FaqPage.js
@@ -129,7 +129,7 @@ function FaqTable() {
 	const maxOpenedId = (1 << faqData.length) - 1;
 	const isFullyExtended = (openedId === maxOpenedId);
 	
-	const CollapsingStrategy = {
+	const ExpansionStrategy = {
 		SINGLE: function (id) {
 			this.toggleFaqRow = () => setOpenedId( (this.isOpened? 0 : 1) << id );
 			this.isOpened = !!((openedId >> id) & 1);
@@ -143,7 +143,7 @@ function FaqTable() {
 	const defaultStrategy = "SINGLE";
 	const otherStrategy = "MULTIPLE";
 	const [strategyId, setStrategyId] = React.useState(defaultStrategy);
-	let Strategy = CollapsingStrategy[strategyId];
+	let Strategy = ExpansionStrategy[strategyId];
 
 	return (<>
 		<div style={{ display: "flex", }}>
@@ -174,7 +174,7 @@ function FaqQuestionRow({ strategy, row }) {
 			<TableRow>
 				<TableCell component="th" scope="row" onClick={strategy.toggleFaqRow} style={{ borderBottom: "none", paddingLeft: "0px", paddingBottom: "10px", paddingTop: "25px" }}>
 					<HeaderTypography style={{ color: strategy.isOpened ? activeTextColor : textColor, cursor: "pointer", fontSize: "20px", fontWeight: "bold", userSelect: "none" }} >
-						{row.title}
+						{row.title}&nbsp;
 						<img src={ strategy.isOpened ? RightArrowGreen : RightArrowWhite } alt="->"/>
 					</HeaderTypography>
 				</TableCell>

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -10,7 +10,7 @@ import Box from "@mui/material/Box";
 import { Link } from "react-router-dom";
 import CenterFlexBox from "../components/CenterFlexBox";
 import appwriteApi from "../api/appwriteApi";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Divider } from "@mui/material";
 import useChangeRoute from "../hooks/useChangeRoute";
 import { inputFieldStyle } from "../assets/jss/InputFieldJSS";
@@ -44,9 +44,8 @@ export default function Login({ user, setUser }) {
 			});
 	};
 
-	if (user) {
-		changeRoute("/");
-	}
+	// "changeRoute" is a state update and therefore should only be used in useEffect or event handlers
+	useEffect(() => user && changeRoute("/"), [user]);
 	return (
 		<CenterFlexBox>
 			<ParagraphTypography component="h1" variant="h5" style={{ paddingBottom: "29px" }}>

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -73,7 +73,7 @@ const ProfileSetting = ({ label, inputFieldList = [], inputColumnExtra = "", inp
 	const textFieldColor = (alpha) => `rgba(255,255,255,${alpha})`;
 	// TODO create a text field theme instead
 	const textFieldStyle = { border: `1px solid ${textFieldColor(0.5)}`, borderRadius: "7px", fontWeight: "400", fontSize: "16px", };
-	const textFieldSX = { input: { "-webkit-text-fill-color": `${textFieldColor(0.6)} !important`, "color": `${textFieldColor(0.6)} !important`, }, label: { color: textFieldColor(0.6) } };
+	const textFieldSX = { input: { WebkitTextFillColor: `${textFieldColor(0.6)} !important`, color: `${textFieldColor(0.6)} !important`, }, label: { color: textFieldColor(0.6) } };
 
 	const left = (
 		<HeaderTypography style={{ fontWeight: "700", fontSize: "18px", color: textColor }}>

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -9,7 +9,7 @@ import TextField from "@mui/material/TextField";
 import React, { useEffect, useState } from "react";
 import appwriteApi from "../api/appwriteApi";
 import useChangeRoute from "../hooks/useChangeRoute";
-import { textColor, activeTextColor, } from "../assets/jss/colorPalette";
+import { textColor, } from "../assets/jss/colorPalette";
 
 import { Margin, Image, CenterBox, } from "../components/Common";
 import ParagraphTypography from "../components/ParagraphTypography";
@@ -196,18 +196,15 @@ export default function Profile({ user, setUser }) {
 			label: "Log out",
 			inputColumnExtra: <LogoutButton setUser={setUser} changeRoute={changeRoute} />, 
 		},
-		{
-			inputColumnExtra: saveButton,
-		}
 	];
 
 	// TODO live text input validation
 	const pictureLabel = "Userpic";
 	const pictureRequirementsText = "max 180x180";  // TODO
 	const usernameLabel = "Username";
-	const usernameRequirementsText = "letters, digits, punctuation";  // TODO
+	const usernameRequirementsText = "";  // TODO
 	const emailLabel = "Email";
-	const emailRequirementsText = "letters, digits, .+-@ ";
+	const emailRequirementsText = "";   // TODO
 	const passwordLabel = "Change password";
 	const passwordRequirementsText = "";  // TODO, I find password limitations useless
 
@@ -270,12 +267,6 @@ export default function Profile({ user, setUser }) {
 				</ButtonLinkTypography>
 			</div>);
 	};
-
-	const saveButton = (<CenterBox>
-		<RoundedEdgesButton type="submit" style={{ backgroundColor: activeTextColor, width: "151px" }} >
-			Save profile
-		</RoundedEdgesButton>
-	</CenterBox>);
 
 	return render();
 }


### PR DESCRIPTION
There were multiple display bugs.

On changes or updates, it mainly wouldn't reload correctly while the action took place under the hood.

Did also minor refactorings here. The buggy RestrictedArea is updated as well (like in my other PR).

Unfortunately, Appwrite seems to be not working correctly. The announcements initially added via Python cannot be found by using the JavaScript API, even when loading those documents explicitly via their document ID.

One could also use Appwrite's API for listing database documents in a sorted way but the API seems to be unstable. It just was changed between v0.11 and v0.12 so a custom solution remains better in my opinion.